### PR TITLE
Make ID-JAG a standalone concept that isn't tied to Token Exchange

### DIFF
--- a/draft-ietf-oauth-identity-assertion-authz-grant.md
+++ b/draft-ietf-oauth-identity-assertion-authz-grant.md
@@ -341,7 +341,7 @@ The IdP may also introspect the authentication context described in the SSO asse
 
 ### Response
 
-If access is granted, the IdP creates a signed Identity Assertion Authorization Grant JWT and returns it in the token exchange response defined in Section 2.2 of {{RFC8693}}:
+If access is granted, the IdP creates a signed Identity Assertion Authorization Grant JWT ({{jwt-authorization-grant}}) and returns it in the token exchange response defined in Section 2.2 of {{RFC8693}}:
 
     HTTP/1.1 200 OK
     Content-Type: application/json


### PR DESCRIPTION
Moved ID-JAG to document root to make clear that its a standalone concept as replacement of ID token for cross-domain identity assertion that is being defined in this spec.  It could be obtained by different flows in the future (e.g additional `response_type` on authorization endpoint).

- Attempted to clarify the ID-JAG is a profile of JWT Authorization Grant
- Adopted proposed `tenant` claim
- Adopted authentication claims from ID Token