### PR TITLE
Profile access_denied for authorization failures at IdP and RAS

### DIFF
--- a/draft-ietf-oauth-identity-assertion-authz-grant.md
+++ b/draft-ietf-oauth-identity-assertion-authz-grant.md
@@ -732,18 +732,23 @@ Access Token Response:
       ]
     }
 
-#### Error Response
+#### Error Response {#token-exchange-error-response}
 
-On an error condition, the IdP returns an OAuth 2.0 Token Error response as defined in {{Section 5.2 of RFC6749}}, e.g:
+On error, the IdP Authorization Server returns an OAuth 2.0 Token Error response as defined in {{Section 5.2 of RFC6749}}. Any OAuth error code MAY be returned; this specification profiles the following two codes for interoperability:
 
-    HTTP/1.1 400 Bad Request
-    Content-Type: application/json
-    Cache-Control: no-store
+* `invalid_grant`: the subject token failed validation (for example expired, malformed, audience mismatch, or a Refresh Token is expired or revoked). A re-issued subject token may resolve the error.
 
-    {
-      "error": "invalid_grant",
-      "error_description": "Audience validation failed"
-    }
+      {
+        "error": "invalid_grant",
+        "error_description": "Audience validation failed"
+      }
+
+* `access_denied`: the subject token is valid but the Client or End-User is not authorized to obtain an ID-JAG for the target Resource Authorization Server. A re-issued subject token will not resolve the error. Remediation is defined by the IdP Authorization Server operator's app assignment, access-request, or entitlement process, such as an Identity Governance and Administration (IGA) workflow.
+
+      {
+        "error": "access_denied",
+        "error_description": "Client is not authorized to broker access to the target Resource Authorization Server"
+      }
 
 
 ## Access Token Request {#token-request}
@@ -810,6 +815,24 @@ The Resource Authorization Server's token endpoint responds with an OAuth 2.0 To
       "expires_in": 86400,
       "scope": "chat.read chat.history"
     }
+
+### Error Response {#access-token-error-response}
+
+On error, the Resource Authorization Server returns an OAuth 2.0 Token Error response as defined in {{Section 5.2 of RFC6749}}. Any OAuth error code MAY be returned; this specification profiles the following two codes for interoperability:
+
+* `invalid_grant`: the ID-JAG failed a validation rule in {{token-request}} (for example signature, `aud`, `client_id`, `exp`, `typ`, decryption, or `cnf` binding). A re-issued ID-JAG may resolve the error.
+
+      {
+        "error": "invalid_grant",
+        "error_description": "Audience validation failed"
+      }
+
+* `access_denied`: the ID-JAG is valid but the End-User or Client is not authorized at the Resource Authorization Server (for example the End-User lacks a license, entitlement, or provisioning record, or is denied by the Resource Authorization Server's policy or role/permission assignments). A re-issued ID-JAG will not resolve the error. Remediation is defined by the Resource Authorization Server operator's access-request, entitlement, or provisioning process, such as an Identity Governance and Administration (IGA) workflow.
+
+      {
+        "error": "access_denied",
+        "error_description": "The end-user is not licensed for this application"
+      }
 
 ### Refresh Token
 


### PR DESCRIPTION
Closes #111.

## Summary

Addresses @pcarleton's report in #111 that RAS-side authorization failures (for example "the End-User does not have a license", or a policy or role check that denies access) today return `invalid_grant`, which is indistinguishable from grant validation failures such as signature or audience mismatches. Clients cannot tell whether a fresh ID-JAG would resolve the error or whether the End-User needs to remediate through an entitlement or access-request process.

Per the discussion on #111, this PR adopts the path @aaronpk agreed to: profile `access_denied` for authorization failures at both the IdP Token Exchange endpoint and the RAS ID-JAG-to-access-token exchange, keeping `invalid_grant` for grant validation failures.

## What changed

Adds an Error Response subsection under Access Token Request and expands the existing Error Response subsection under Token Exchange. Each section:

- Opens with a one-sentence framing noting that any OAuth token endpoint error code MAY be returned and that these two codes are profiled specifically for interoperability.
- Defines `invalid_grant` as the grant validation failure code (signature, `aud`, `client_id`, `exp`, `typ`, decryption, `cnf` binding, subject token expiration at the IdP, etc.). A re-issued grant may resolve the error.
- Defines `access_denied` as the authorization failure code (the grant is valid but the End-User or Client is not authorized). Covers licensing, entitlement, and provisioning gaps as well as policy or role/permission denials. A re-issued grant will not resolve the error.
- Points at operator-defined remediation. Both bullets frame this as the "operator's access-request, entitlement, or provisioning process" (IdP-side adds "app assignment" as the leading example), with Identity Governance and Administration (IGA) workflows called out as a concrete enterprise deployment shape.

The two sections stay parallel and self-contained so readers of either endpoint's flow can consume the full error semantics without cross-referencing.

## How this responds to #111

| Concern | Resolution |
|---|---|
| RAS-side "user does not have a license" returns `invalid_grant`, indistinguishable from misconfiguration | New `access_denied` bullet at the RAS with explicit license, entitlement, provisioning, and policy/role denial examples |
| Client cannot tell when to retry vs when to send the user through an access-request process | Each bullet states whether re-issuing the grant will resolve the error, giving the client a clear retry signal |
| Same class of failure exists at the IdP side | Parallel `access_denied` bullet at the IdP for "Client or End-User not authorized to obtain an ID-JAG for the target Resource Authorization Server" |
| Remediation is deployment-specific (enterprise IGA, or other operator processes) | Remediation sentence points to the operator's process and names IGA as a concrete example without foreclosing other deployment shapes |

## Not in this PR (for future work)

The #111 discussion also mentioned:

- `insufficient_user_authentication` — already covered in PR #88, so intentionally not touched here.
- `insufficient_claims` (`draft-mcguinness-oauth-insufficient-claims`) — separate individual draft; would land as a follow-up if adopted.
- `interaction_required` (`draft-parecki-oauth-jwt-grant-interaction-response`) — separate individual draft; would land as a follow-up if adopted.

## Test plan

- [ ] Render with kramdown-rfc / xml2rfc and confirm the new Error Response sections render correctly
- [ ] Confirm cross-references (`{{Section 5.2 of RFC6749}}`, `{{token-request}}`) resolve
- [ ] Confirm the new `{#token-exchange-error-response}` and `{#access-token-error-response}` anchors are unique and available for later specs to reference