### PR TITLE
Add native support for workload and autonomous agent Principals

### DIFF
--- a/draft-ietf-oauth-identity-assertion-authz-grant.md
+++ b/draft-ietf-oauth-identity-assertion-authz-grant.md
@@ -99,8 +99,6 @@ informative:
   RFC9470:
   RFC9728:
   I-D.ietf-oauth-client-id-metadata-document:
-  I-D.ietf-oauth-attestation-based-client-auth:
-  I-D.mcguinness-oauth-client-instance-assertion:
 
 --- abstract
 
@@ -159,10 +157,10 @@ Principal
 : The entity the Identity Assertion is issued for. The Principal may be an End-User, a workload, or an autonomous agent.
 
 Identity Assertion
-: A security token that conveys claims about a Principal and can be used as the `subject_token` input to Token Exchange. In this specification, an Identity Assertion is one of:
+: A security token that conveys claims about a Principal and can be used as the `subject_token` input to Token Exchange. In this specification, an Identity Assertion is:
 
-  * an OpenID Connect ID Token or a SAML 2.0 assertion issued by the IdP Authorization Server for an End-User Principal;
-  * a Client Assertion per {{RFC7523}}, a Client Attestation per {{I-D.ietf-oauth-attestation-based-client-auth}}, or a Client Instance Assertion per {{I-D.mcguinness-oauth-client-instance-assertion}} for a workload or autonomous agent Principal.
+  * an OpenID Connect ID Token or a SAML 2.0 assertion issued by the IdP Authorization Server for an End-User Principal; or
+  * a JWT credential the workload or agent presents to authenticate as the Principal to the IdP Authorization Server, for a workload or autonomous agent Principal. Any JWT-based client authentication method the IdP Authorization Server accepts for that Principal MAY be used, including those registered under the `token_endpoint_auth_methods_supported` authorization server metadata parameter. See {{workload-agent-principal}}.
 
 Trust Domain
 : A deployment-specific security and administrative boundary within which a set of entities, identifiers, credentials, and policy decisions are mutually trusted according to established trust relationships. In this specification, the IdP Authorization Server operates in trust domain A, while the Resource Authorization Server and Resource Server operate in trust domain B.
@@ -350,10 +348,23 @@ An ID-JAG MAY represent a workload or autonomous agent Principal in addition to 
 
 When the Principal is a workload or autonomous agent:
 
-* The `subject_token` used in the Token Exchange is a Client Assertion per {{RFC7523}}, a Client Attestation per {{I-D.ietf-oauth-attestation-based-client-auth}}, or a Client Instance Assertion per {{I-D.mcguinness-oauth-client-instance-assertion}}. Its `subject_token_type` is `urn:ietf:params:oauth:token-type:jwt`.
+* The `subject_token` is a JWT credential the workload or agent uses to authenticate as the Principal to the IdP Authorization Server. Any JWT-based client authentication method the IdP Authorization Server accepts for that Principal MAY be used, including those registered under `token_endpoint_auth_methods_supported`. The same JWT MAY serve as both the client authentication credential and the `subject_token`. Its `subject_token_type` is `urn:ietf:params:oauth:token-type:jwt`.
 * The `sub` claim of the resulting ID-JAG is the workload or agent identifier the IdP Authorization Server assigns to the Principal.
 * Claims specific to End-User authentication (`auth_time`, `acr`, `amr`, `email`) are typically absent.
 * The Resource Authorization Server resolves the workload or agent as a first-class Principal, not as a delegated actor for an End-User.
+
+A JWT presented as a workload or autonomous agent Identity Assertion MUST contain the following claims:
+
+* `iss` (issuer): identifies the party that issued the JWT (for example, the workload itself for a self-signed client assertion, an attestation authority for an attested credential, or a SPIFFE trust domain).
+* `sub` (subject): identifies the workload or autonomous agent Principal.
+* `aud` (audience): identifies the IdP Authorization Server, typically its token endpoint URL or its issuer identifier.
+* `exp` (expiration time): the JWT's expiration time. The IdP MUST reject expired credentials.
+
+A JWT SHOULD additionally contain `iat` (issued at) and `jti` (JWT ID) for replay detection.
+
+The IdP Authorization Server determines what forms of workload or agent Identity Assertion it accepts based on local policy. Deployments MAY require credentials that convey runtime attestation (for example, workload attestation or TEE attestation), a specific trusted issuer (such as a SPIFFE trust domain or a client backend attestation service), or other trust-establishment properties in addition to identifying the Principal. The IdP MUST validate the credential per the applicable client authentication specification before minting the ID-JAG.
+
+Client authentication methods that do not produce a JWT body artifact (for example, mTLS-based mechanisms) do not directly yield a `subject_token` for this profile; a companion profile MAY define how such a mechanism produces an equivalent JWT Identity Assertion.
 
 The Resource Authorization Server determines whether it accepts an ID-JAG whose Principal is a workload or autonomous agent based on local policy for the issuer and the requested audience. See {{workload-principal-security}} for additional security considerations.
 
@@ -470,7 +481,7 @@ The Client makes a Token Exchange {{RFC8693}} request to the IdP Authorization S
 : OPTIONAL - A JSON string containing a JSON array of authorization detail objects as defined in {{Section 2 of RFC9396}}. This parameter enables Rich Authorization Requests (RAR) support, allowing structured authorization requests beyond simple scope strings.
 
 `subject_token`:
-: REQUIRED - An Identity Assertion for the Principal that will be represented by the ID-JAG, or a Refresh Token previously issued by the IdP Authorization Server for that Principal. The Identity Assertion is an OpenID Connect ID Token or a SAML 2.0 Assertion for an End-User Principal, or a Client Assertion per {{RFC7523}}, a Client Attestation per {{I-D.ietf-oauth-attestation-based-client-auth}}, or a Client Instance Assertion per {{I-D.mcguinness-oauth-client-instance-assertion}} for a workload or autonomous agent Principal. Implementations of this specification MUST accept OpenID Connect ID Tokens as Identity Assertions. They MAY additionally accept SAML 2.0 Assertions, workload or agent Identity Assertions, and Refresh Tokens to allow the client to obtain a new ID-JAG without performing a new single sign-on round trip when the Identity Assertion has expired.
+: REQUIRED - An Identity Assertion for the Principal that will be represented by the ID-JAG, or a Refresh Token previously issued by the IdP Authorization Server for that Principal. The Identity Assertion is an OpenID Connect ID Token or a SAML 2.0 Assertion for an End-User Principal, or a JWT credential the workload or agent presents to authenticate as the Principal (see {{workload-agent-principal}}) for a workload or autonomous agent Principal. Implementations of this specification MUST accept OpenID Connect ID Tokens as Identity Assertions. They MAY additionally accept SAML 2.0 Assertions, workload or agent Identity Assertions, and Refresh Tokens to allow the client to obtain a new ID-JAG without performing a new single sign-on round trip when the Identity Assertion has expired.
 
 `subject_token_type`:
 : REQUIRED - An identifier, as described in {{Section 3 of RFC8693}}, that indicates the type of the security token in the `subject_token` parameter. For an OpenID Connect ID Token: `urn:ietf:params:oauth:token-type:id_token`, for a SAML 2.0 Assertion: `urn:ietf:params:oauth:token-type:saml2`, for a Client Assertion, Client Attestation, or Client Instance Assertion (when supported): `urn:ietf:params:oauth:token-type:jwt`, and for a Refresh Token (when supported): `urn:ietf:params:oauth:token-type:refresh_token`.
@@ -552,7 +563,7 @@ This non-normative example shows using a Refresh Token as the `subject_token` (w
 The IdP MUST validate the subject token:
 
 * If the subject token is an End-User Identity Assertion (OpenID Connect ID Token or SAML 2.0 assertion), the IdP MUST validate the assertion and MUST validate that the audience of the assertion (e.g. the `aud` claim of the ID Token or SAML Audience) matches the `client_id` of the client authentication of the request.
-* If the subject token is a workload or autonomous agent Identity Assertion (Client Assertion, Client Attestation, or Client Instance Assertion), the IdP MUST validate the assertion per the applicable specification and MUST resolve the Principal identified by the assertion to a workload or agent registration the IdP administers. The audience of these assertions is the IdP Authorization Server (typically its token endpoint) rather than the `client_id`; the mapping between the authenticated OAuth client and the workload or agent Principal is a policy decision at the IdP.
+* If the subject token is a workload or autonomous agent Identity Assertion, the IdP MUST validate the JWT per the applicable client authentication specification, verify the required claims per {{workload-agent-principal}}, and resolve the Principal identified by the credential to a workload or agent registration the IdP administers. The audience of these assertions is the IdP Authorization Server (typically its token endpoint) rather than the `client_id`; the mapping between the authenticated OAuth client and the workload or agent Principal is a policy decision at the IdP.
 * If the subject token is a Refresh Token, the IdP MUST validate it the same way it would for a standard `refresh_token` grant at the token endpoint: the token is issued by the IdP, bound to the authenticated client, unexpired, not revoked, and the requested scopes and audience remain within the authorization context of the Refresh Token.
 * If the subject token is a Refresh Token, the IdP Authorization Server SHOULD retrieve or assemble the subject's claims needed for the ID-JAG in the same way it would when issuing a new Identity Assertion during a token request, so that the resulting ID-JAG reflects current subject attributes and policy.
 
@@ -1080,7 +1091,7 @@ When such profiles or extensions use an `act` claim, they should preserve the di
 
 When an ID-JAG represents a workload or autonomous agent Principal, the End-User consent semantics that normally apply to cross-app access ({{OpenID.Core}}) do not apply. The IdP Authorization Server MUST have an administratively established authorization basis (registration, policy, or attestation trust) for issuing ID-JAGs on behalf of the workload or agent, in place of an End-User consent event.
 
-The IdP Authorization Server SHOULD validate the workload or agent Identity Assertion (Client Assertion, Client Attestation, or Client Instance Assertion) using the same trust anchors and validation rules it would apply for the equivalent client authentication or client attestation.
+The IdP Authorization Server SHOULD validate the workload or agent Identity Assertion using the same trust anchors and validation rules it would apply for the equivalent client authentication method, including any attestation, instance-binding, or issuer-trust requirements the IdP has configured for that Principal.
 
 The Resource Authorization Server SHOULD apply local policy to decide whether the workload or agent Principal identified by an ID-JAG is authorized for the requested audience, resource, scope, and authorization details. In particular, the Resource Authorization Server SHOULD NOT infer End-User attributes from a workload or agent ID-JAG, and SHOULD NOT rely on the presence of End-User claims (`auth_time`, `acr`, `amr`, `email`) which will typically be absent.
 
@@ -1654,7 +1665,7 @@ The authors would like to thank the following people for their contributions and
 
 -05
 
-* Added native support for workload and autonomous agent Principals: broadened the definition of Identity Assertion to include Client Assertion, Client Attestation, and Client Instance Assertion; broadened the `sub` claim to identify a Principal (End-User, workload, or agent); added Section 3.3 describing Workload and Autonomous Agent Principals; extended Token Exchange processing rules to validate workload and agent Identity Assertions; added a Security Considerations subsection on workload and agent Principals.
+* Added native support for workload and autonomous agent Principals: introduced the Principal term; broadened the Identity Assertion definition to include any JWT-based client authentication credential the IdP Authorization Server accepts for a workload or agent Principal (including those registered under `token_endpoint_auth_methods_supported`); broadened the `sub` claim to identify a Principal (End-User, workload, or agent); added Section 3.3 describing Workload and Autonomous Agent Principals with JWT invariants (`iss`, `sub`, `aud`, `exp` REQUIRED; `iat`, `jti` SHOULD) and guidance on IdP policy for attestation and trusted issuers; extended Token Exchange processing rules to validate workload and agent Identity Assertions; added a Security Considerations subsection on workload and agent Principals.
 
 -04
 

--- a/draft-ietf-oauth-identity-assertion-authz-grant.md
+++ b/draft-ietf-oauth-identity-assertion-authz-grant.md
@@ -99,6 +99,8 @@ informative:
   RFC9470:
   RFC9728:
   I-D.ietf-oauth-client-id-metadata-document:
+  I-D.ietf-oauth-attestation-based-client-auth:
+  I-D.mcguinness-oauth-client-instance-assertion:
 
 --- abstract
 
@@ -153,8 +155,14 @@ Common OAuth and token processing terms such as client, authorization server, re
 
 OpenID Connect terms such as end-user, Relying Party, OpenID Provider, ID Token, subject identifier, and pairwise subject identifier are used as defined in OpenID Connect Core 1.0 {{OpenID.Core}}, unless otherwise specified by this document.
 
+Principal
+: The entity the Identity Assertion is issued for. The Principal may be an End-User, a workload, or an autonomous agent.
+
 Identity Assertion
-: A security token issued by the IdP Authorization Server that conveys claims about the End-User and can be used as the `subject_token` input to Token Exchange. In this specification, the Identity Assertion is typically an OpenID Connect ID Token or a SAML 2.0 assertion.
+: A security token that conveys claims about a Principal and can be used as the `subject_token` input to Token Exchange. In this specification, an Identity Assertion is one of:
+
+  * an OpenID Connect ID Token or a SAML 2.0 assertion issued by the IdP Authorization Server for an End-User Principal;
+  * a Client Assertion per {{RFC7523}}, a Client Attestation per {{I-D.ietf-oauth-attestation-based-client-auth}}, or a Client Instance Assertion per {{I-D.mcguinness-oauth-client-instance-assertion}} for a workload or autonomous agent Principal.
 
 Trust Domain
 : A deployment-specific security and administrative boundary within which a set of entities, identifiers, credentials, and policy decisions are mutually trusted according to established trust relationships. In this specification, the IdP Authorization Server operates in trust domain A, while the Resource Authorization Server and Resource Server operate in trust domain B.
@@ -177,7 +185,7 @@ Tenant
 
 # Identity Assertion JWT Authorization Grant {#id-jag}
 
-The Identity Assertion JWT Authorization Grant (ID-JAG) is a profile of the JWT Authorization Grant {{RFC7523}} that grants a client delegated access to a resource in another trust domain on behalf of a user without a direct user-approval step at the authorization server. In addition to traditional OAuth scope-based authorization, this specification can be extended with Rich Authorization Requests (RAR) {{RFC9396}}, allowing clients to request limited authorization using structured authorization details.
+The Identity Assertion JWT Authorization Grant (ID-JAG) is a profile of the JWT Authorization Grant {{RFC7523}} that grants a client delegated access to a resource in another trust domain on behalf of a Principal (End-User, workload, or autonomous agent) without a direct user-approval step at the authorization server. In addition to traditional OAuth scope-based authorization, this specification can be extended with Rich Authorization Requests (RAR) {{RFC9396}}, allowing clients to request limited authorization using structured authorization details.
 
 An ID-JAG is issued and signed by an IdP Authorization Server similar to an ID Token {{OpenID.Core}}, and contains claims about an End-User. Instead of being issued for a Client (Relying Party in {{OpenID.Core}}) as the intended audience for the assertion, it is instead issued with an audience of an Authorization Server in another trust domain (Resource Authorization Server). It replaces the need for the client to obtain an authorization code from the Resource Authorization Server to delegate access to the client, and instead uses the IdP Authorization Server that is trusted by the Resource Authorization Server for SSO and subject resolution to delegate access to the client. The Resource Authorization Server still applies local policy when deciding whether to honor the ID-JAG and what access token to issue.
 
@@ -191,7 +199,7 @@ The following claims are used within the Identity Assertion JWT Authorization Gr
 : REQUIRED - The issuer identifier of the IdP Authorization Server as defined in {{RFC8414}}.
 
 `sub`:
-: REQUIRED - Subject Identifier. An identifier within the IdP Authorization Server for the End-User, which is intended to be consumed by the Client as defined in {{OpenID.Core}}. The `sub` claim identifies the End-User in the subject namespace of the ID-JAG issuer. When the Resource Authorization Server uses a different subject namespace for SSO, such as a SAML Assertion Subject `<NameID>` namespace, the ID-JAG MAY include `sub_id` to carry the SSO subject identifier. When both `sub` and `sub_id` are present, they MUST identify the same End-User. A public subject identifier MUST be unique when scoped with issuer (`iss`+`sub`) for a single-tenant issuer and MUST be unique when scoped with issuer and tenant (`iss`+`tenant`+`sub`) for multi-tenant issuer. See {{client-id-mapping}} for additional considerations.
+: REQUIRED - Subject Identifier. An identifier within the IdP Authorization Server for the Principal represented by this ID-JAG. For an End-User Principal, `sub` is the Subject Identifier as defined in {{OpenID.Core}}. For a workload or autonomous agent Principal, `sub` is the identifier the IdP Authorization Server assigns to that workload or agent. The `sub` claim identifies the Principal in the subject namespace of the ID-JAG issuer. When the Resource Authorization Server uses a different subject namespace for SSO, such as a SAML Assertion Subject `<NameID>` namespace, the ID-JAG MAY include `sub_id` to carry the SSO subject identifier. When both `sub` and `sub_id` are present, they MUST identify the same Principal. A public subject identifier MUST be unique when scoped with issuer (`iss`+`sub`) for a single-tenant issuer and MUST be unique when scoped with issuer and tenant (`iss`+`tenant`+`sub`) for multi-tenant issuer. See {{client-id-mapping}} for additional considerations.
 
 `sub_id`:
 : OPTIONAL - Subject Identifier as defined in {{RFC9493}}. The `sub_id` claim MAY be used to identify the same End-User as the `sub` claim using a different identifier namespace from the ID-JAG `iss` and `sub`. This is useful when the Resource Authorization Server resolves users by a non-JWT subject identifier, such as a SAML Assertion Subject `<NameID>`, in its SSO trust relationship with the IdP Authorization Server. See {{saml-nameid-format}} for the SAML NameID Subject Identifier Format defined by this specification, and {{saml-nameid-sub-id-processing}} for processing rules.
@@ -336,6 +344,19 @@ If the Resource Authorization Server requires a SAML NameID Subject Identifier f
 
 See {{sub-id-trust}} and {{sub-id-disclosure}} for security considerations on the `sub_id` claim.
 
+## Workload and Autonomous Agent Principals {#workload-agent-principal}
+
+An ID-JAG MAY represent a workload or autonomous agent Principal in addition to an End-User Principal. This supports cross-domain single sign-on for services and autonomous agents that act as themselves, without an End-User in the loop.
+
+When the Principal is a workload or autonomous agent:
+
+* The `subject_token` used in the Token Exchange is a Client Assertion per {{RFC7523}}, a Client Attestation per {{I-D.ietf-oauth-attestation-based-client-auth}}, or a Client Instance Assertion per {{I-D.mcguinness-oauth-client-instance-assertion}}. Its `subject_token_type` is `urn:ietf:params:oauth:token-type:jwt`.
+* The `sub` claim of the resulting ID-JAG is the workload or agent identifier the IdP Authorization Server assigns to the Principal.
+* Claims specific to End-User authentication (`auth_time`, `acr`, `amr`, `email`) are typically absent.
+* The Resource Authorization Server resolves the workload or agent as a first-class Principal, not as a delegated actor for an End-User.
+
+The Resource Authorization Server determines whether it accepts an ID-JAG whose Principal is a workload or autonomous agent based on local policy for the issuer and the requested audience. See {{workload-principal-security}} for additional security considerations.
+
 # Cross-Domain Access
 
 ## Overview
@@ -449,10 +470,10 @@ The Client makes a Token Exchange {{RFC8693}} request to the IdP Authorization S
 : OPTIONAL - A JSON string containing a JSON array of authorization detail objects as defined in {{Section 2 of RFC9396}}. This parameter enables Rich Authorization Requests (RAR) support, allowing structured authorization requests beyond simple scope strings.
 
 `subject_token`:
-: REQUIRED - Either the Identity Assertion (e.g. the OpenID Connect ID Token or SAML 2.0 Assertion) for the target resource owner, or a Refresh Token previously issued by the IdP Authorization Server for that resource owner. Implementations of this specification MUST accept Identity Assertions. They MAY additionally accept Refresh Tokens to allow the client to obtain a new ID-JAG without performing a new single sign-on round trip when the Identity Assertion has expired.
+: REQUIRED - An Identity Assertion for the Principal that will be represented by the ID-JAG, or a Refresh Token previously issued by the IdP Authorization Server for that Principal. The Identity Assertion is an OpenID Connect ID Token or a SAML 2.0 Assertion for an End-User Principal, or a Client Assertion per {{RFC7523}}, a Client Attestation per {{I-D.ietf-oauth-attestation-based-client-auth}}, or a Client Instance Assertion per {{I-D.mcguinness-oauth-client-instance-assertion}} for a workload or autonomous agent Principal. Implementations of this specification MUST accept OpenID Connect ID Tokens as Identity Assertions. They MAY additionally accept SAML 2.0 Assertions, workload or agent Identity Assertions, and Refresh Tokens to allow the client to obtain a new ID-JAG without performing a new single sign-on round trip when the Identity Assertion has expired.
 
 `subject_token_type`:
-: REQUIRED - An identifier, as described in {{Section 3 of RFC8693}}, that indicates the type of the security token in the `subject_token` parameter. For an OpenID Connect ID Token: `urn:ietf:params:oauth:token-type:id_token`, for a SAML 2.0 Assertion: `urn:ietf:params:oauth:token-type:saml2`, and for a Refresh Token (when supported): `urn:ietf:params:oauth:token-type:refresh_token`.
+: REQUIRED - An identifier, as described in {{Section 3 of RFC8693}}, that indicates the type of the security token in the `subject_token` parameter. For an OpenID Connect ID Token: `urn:ietf:params:oauth:token-type:id_token`, for a SAML 2.0 Assertion: `urn:ietf:params:oauth:token-type:saml2`, for a Client Assertion, Client Attestation, or Client Instance Assertion (when supported): `urn:ietf:params:oauth:token-type:jwt`, and for a Refresh Token (when supported): `urn:ietf:params:oauth:token-type:refresh_token`.
 
 When a Refresh Token is used as the subject token, the client still requests `requested_token_type=urn:ietf:params:oauth:token-type:id-jag`; this allows the client to refresh an Identity Assertion JWT Authorization Grant without fetching a new Identity Assertion from the user-facing SSO flow.
 
@@ -530,7 +551,8 @@ This non-normative example shows using a Refresh Token as the `subject_token` (w
 
 The IdP MUST validate the subject token:
 
-* If the subject token is an Identity Assertion, the IdP MUST validate the assertion and MUST validate that the audience of the assertion (e.g. the `aud` claim of the ID Token or SAML Audience) matches the `client_id` of the client authentication of the request.
+* If the subject token is an End-User Identity Assertion (OpenID Connect ID Token or SAML 2.0 assertion), the IdP MUST validate the assertion and MUST validate that the audience of the assertion (e.g. the `aud` claim of the ID Token or SAML Audience) matches the `client_id` of the client authentication of the request.
+* If the subject token is a workload or autonomous agent Identity Assertion (Client Assertion, Client Attestation, or Client Instance Assertion), the IdP MUST validate the assertion per the applicable specification and MUST resolve the Principal identified by the assertion to a workload or agent registration the IdP administers. The audience of these assertions is the IdP Authorization Server (typically its token endpoint) rather than the `client_id`; the mapping between the authenticated OAuth client and the workload or agent Principal is a policy decision at the IdP.
 * If the subject token is a Refresh Token, the IdP MUST validate it the same way it would for a standard `refresh_token` grant at the token endpoint: the token is issued by the IdP, bound to the authenticated client, unexpired, not revoked, and the requested scopes and audience remain within the authorization context of the Refresh Token.
 * If the subject token is a Refresh Token, the IdP Authorization Server SHOULD retrieve or assemble the subject's claims needed for the ID-JAG in the same way it would when issuing a new Identity Assertion during a token request, so that the resulting ID-JAG reflects current subject attributes and policy.
 
@@ -1053,6 +1075,16 @@ Profiles or extensions that define use of `actor_token` need to consider delegat
 Such profiles or extensions should define how `actor_token` is validated, how the relationship between the authenticated client, subject, and actor is authorized, how any resulting `act` claim is derived, and how unnecessary disclosure of actor identity or attributes is minimized across trust domains.
 
 When such profiles or extensions use an `act` claim, they should preserve the distinction between the actor identified by `act` and the resource owner identified by `sub`. The authenticated client identity is also not a substitute for actor identity.
+
+## Workload and Autonomous Agent Principals {#workload-principal-security}
+
+When an ID-JAG represents a workload or autonomous agent Principal, the End-User consent semantics that normally apply to cross-app access ({{OpenID.Core}}) do not apply. The IdP Authorization Server MUST have an administratively established authorization basis (registration, policy, or attestation trust) for issuing ID-JAGs on behalf of the workload or agent, in place of an End-User consent event.
+
+The IdP Authorization Server SHOULD validate the workload or agent Identity Assertion (Client Assertion, Client Attestation, or Client Instance Assertion) using the same trust anchors and validation rules it would apply for the equivalent client authentication or client attestation.
+
+The Resource Authorization Server SHOULD apply local policy to decide whether the workload or agent Principal identified by an ID-JAG is authorized for the requested audience, resource, scope, and authorization details. In particular, the Resource Authorization Server SHOULD NOT infer End-User attributes from a workload or agent ID-JAG, and SHOULD NOT rely on the presence of End-User claims (`auth_time`, `acr`, `amr`, `email`) which will typically be absent.
+
+Because workload and agent Principals are not associated with an End-User consent event, deployments SHOULD apply sender constraining to ID-JAGs representing these Principals.
 
 ## Sender Constraining Tokens
 
@@ -1619,6 +1651,10 @@ The authors would like to thank the following people for their contributions and
 {:numbered="false"}
 
 \[\[ To be removed from the final specification ]]
+
+-05
+
+* Added native support for workload and autonomous agent Principals: broadened the definition of Identity Assertion to include Client Assertion, Client Attestation, and Client Instance Assertion; broadened the `sub` claim to identify a Principal (End-User, workload, or agent); added Section 3.3 describing Workload and Autonomous Agent Principals; extended Token Exchange processing rules to validate workload and agent Identity Assertions; added a Security Considerations subsection on workload and agent Principals.
 
 -04
 

--- a/draft-ietf-oauth-identity-assertion-authz-grant.md
+++ b/draft-ietf-oauth-identity-assertion-authz-grant.md
@@ -366,6 +366,8 @@ The IdP Authorization Server determines what forms of workload or agent Identity
 
 Client authentication methods that do not produce a JWT body artifact (for example, mTLS-based mechanisms) do not directly yield a `subject_token` for this profile; a companion profile MAY define how such a mechanism produces an equivalent JWT Identity Assertion.
 
+Except as noted above, the ID-JAG for a workload or autonomous agent Principal is issued using the same mechanics as for an End-User Principal. The IdP Authorization Server MAY map the workload or agent identifier presented in the `subject_token` to a different outbound `sub`, and MAY include `sub_id` and/or `aud_sub` to convey identifiers in namespaces the Resource Authorization Server uses for subject resolution (see {{id-jag}} and {{saml-nameid-subject-identifier}}). The IdP Authorization Server evaluates administrator-defined policy over the requested `audience`, `resource`, `scope`, and `authorization_details` and reflects the granted values in the issued ID-JAG. Subject resolution and JIT provisioning at the Resource Authorization Server follow the same model as for End-User Principals.
+
 The Resource Authorization Server determines whether it accepts an ID-JAG whose Principal is a workload or autonomous agent based on local policy for the issuer and the requested audience. See {{workload-principal-security}} for additional security considerations.
 
 # Cross-Domain Access


### PR DESCRIPTION
## Summary

Addresses [#73](https://github.com/oauth-wg/oauth-identity-assertion-authz-grant/issues/73) (workload/agent as principal). Adds native support in ID-JAG for a Principal that is a workload or autonomous agent, in addition to the existing End-User Principal.

Aligns with the function-based `subject_token` selection framing in [#115](https://github.com/oauth-wg/oauth-identity-assertion-authz-grant/issues/115): a JWT credential the workload or agent presents to authenticate as the Principal is an Identity Assertion for that Principal, and is a valid `subject_token` under this profile.

## Design

The Principal a workload or agent authenticates as is the same Principal the ID-JAG's `sub` identifies. Rather than enumerating specific client authentication specs (Client Assertion, Client Attestation, Client Instance Assertion, SPIFFE, WIMSE, ...), the profile defines the Identity Assertion for a workload/agent Principal by function:

> *"A JWT credential the workload or agent presents to authenticate as the Principal to the IdP Authorization Server. Any JWT-based client authentication method the IdP Authorization Server accepts for that Principal MAY be used, including those registered under the `token_endpoint_auth_methods_supported` authorization server metadata parameter."*

This scales to future client authentication methods without listing each by hand.

## Changes

- **Terminology (§2.2)**: introduces the **Principal** term (End-User, workload, or autonomous agent) and broadens the **Identity Assertion** definition to be function-based, pointing at `token_endpoint_auth_methods_supported` as the mechanism registry.
- **§3 Intro**: broadens "on behalf of a user" to "on behalf of a Principal (End-User, workload, or autonomous agent)".
- **§3.1 `sub` claim**: broadens from End-User Subject Identifier to Principal Identifier.
- **§3.3 Workload and Autonomous Agent Principals** (new): describes when the Principal is a workload or agent; defines JWT invariants (`iss`, `sub`, `aud`, `exp` REQUIRED; `iat`, `jti` SHOULD); and calls out that IdP policy MAY require attestation, specific trusted issuers (e.g., SPIFFE trust domain, WIMSE Identity Server, client backend attestation service), or other trust-establishment properties.
- **§4.3 `subject_token` / `subject_token_type`**: extended to accept workload/agent Identity Assertions with token type `urn:ietf:params:oauth:token-type:jwt`.
- **§4.3 Processing Rules**: adds a rule for validating workload/agent Identity Assertions. The audience of these assertions is the IdP token endpoint (not the `client_id`), and the mapping from authenticated OAuth client to Principal is IdP policy.
- **§9 Security Considerations**: adds a subsection on Workload and Autonomous Agent Principals — absence of End-User consent semantics, validation requirements (including attestation and issuer-trust), RAS-side policy expectations, and a sender-constraining recommendation.
- **-05** document history entry.

## Alignment with existing work

- **[#115](https://github.com/oauth-wg/oauth-identity-assertion-authz-grant/issues/115) (subject_token type selection)**: This PR is a direct application of the function-based framing in #115. Where #115 excludes access tokens because they are resource authorization credentials rather than identity assertions, this PR includes workload/agent client authentication credentials because they ARE identity assertions for the workload or agent Principal. Same primitive, extended to a new Principal type.
- **Composition with `draft-carleton-workload-authz-grant`**: The composition anticipated by draft-carleton §6 — *"the authorization grant's issuer is the customer's Enterprise IdP ... obtained, e.g., by token exchange with the IdP"* — is what this branch enables. ID-JAG covers the Enterprise IdP → cross-domain Resource Authorization Server topology; draft-carleton's platform-direct-issuance topology is complementary rather than subsumed by this PR.
- **Actor delegation** (workload acting on behalf of a user via `act`): out of scope here. See the Actor Profile work.

## Open design questions

### 1. Should ID-JAG support a `sub_profile` claim (from OAuth Entity Profiles) to help RAS processing?

Under this PR, the Principal type (End-User vs. workload vs. autonomous agent) is not carried as an explicit claim. A Resource Authorization Server infers Principal type from context — presence or absence of End-User claims (`auth_time`, `acr`, `amr`, `email`), local policy for the audience, or the shape of the `sub` value.

An explicit `sub_profile` claim (as defined in `draft-mora-oauth-entity-profiles`) would let the RAS branch its processing on the Principal type without inference. Values like `user`, `service`, `ai-agent` would be normative.

**Trade-offs:**

- **For inclusion**: eliminates inference at the RAS; makes Principal type explicit and audit-friendly; aligns with the Entity Profiles direction.
- **Against inclusion**: introduces a dependency on `draft-mora-oauth-entity-profiles` (individual submission, not WG-adopted); adds a new normative claim; the RAS can already infer type from context in most deployments.

**Options:**

1. Leave out (current PR) — Principal type is implicit; RAS infers.
2. Add `sub_profile` as OPTIONAL — deployments that want explicit signaling can use it.
3. Add `sub_profile` as RECOMMENDED — normative signaling with defined values.

### 2. Should ID-JAG add a `subject_token_types_supported` discovery parameter?

The accepted `subject_token_type` values are described in §4.3 as normative text. There is currently no discovery mechanism for a client to learn which types a specific IdP Authorization Server accepts before attempting a Token Exchange request.

For workload/agent Principals this becomes more variable: an IdP might accept ID Tokens and SAML for End-Users but not workload JWT credentials, or vice versa. A workload has no clean way to check without attempting the exchange.

A new AS metadata parameter would signal support explicitly:

```json
{
  "subject_token_types_supported": [
    "urn:ietf:params:oauth:token-type:id_token",
    "urn:ietf:params:oauth:token-type:saml2",
    "urn:ietf:params:oauth:token-type:refresh_token",
    "urn:ietf:params:oauth:token-type:jwt"
  ]
}
```

**Trade-offs:**

- **For inclusion**: runtime discovery avoids failed exchanges; explicit about workload/agent support; scales cleanly if additional `subject_token` types are added later; consistent naming with existing `_supported`-suffixed metadata parameters.
- **Against inclusion**: a new metadata parameter to register and maintain; may duplicate what deployments already communicate out-of-band; overlaps in intent with `authorization_grant_profiles_supported` if per-profile token type info is added there.

**Options:**

1. Leave out (current PR) — no discovery; clients infer from documentation or trial.
2. Add `subject_token_types_supported` — new AS metadata parameter for ID-JAG.
3. Extend `authorization_grant_profiles_supported` with per-profile subject token type info instead of a separate parameter.

Reviewer input on both design questions welcome.

Closes #73.

## Test plan

- [ ] CI builds the draft (kramdown-rfc render succeeds)
- [ ] Internal anchors resolve (`workload-agent-principal`, `workload-principal-security`)
- [ ] Rendered HTML shows §3.3 Workload and Autonomous Agent Principals under the ID-JAG chapter
- [ ] Rendered HTML shows Security Considerations subsection on Workload and Autonomous Agent Principals
- [ ] Document history `-05` entry appears